### PR TITLE
feat: add EditFile and EditBytes helper functions

### DIFF
--- a/yamledit/comment_test.go
+++ b/yamledit/comment_test.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"log"
 
-	"github.com/goccy/go-yaml/parser"
 	"github.com/suzuki-shunsuke/go-yamledit/yamledit"
 )
 
@@ -13,19 +12,15 @@ func ExampleWithComment() {
 - foo
 `
 
-	file, err := parser.ParseBytes([]byte(yml), parser.ParseComments)
-	if err != nil {
-		log.Fatal(err)
-	}
-	act := yamledit.ListAction(
+	s, err := yamledit.EditBytes([]byte(yml), yamledit.ListAction(
 		"$",
 		// Add "zoo" with comment
 		yamledit.AddValuesToList(1, yamledit.WithComment("zoo", " comment is added")),
-	)
-	if err := act.Run(file.Docs[0].Body); err != nil {
+	))
+	if err != nil {
 		log.Fatal(err)
 	}
-	fmt.Println(file.String())
+	fmt.Println(s)
 	// Output:
 	// - foo
 	// - zoo # comment is added

--- a/yamledit/comment_test.go
+++ b/yamledit/comment_test.go
@@ -12,7 +12,7 @@ func ExampleWithComment() {
 - foo
 `
 
-	s, err := yamledit.EditBytes([]byte(yml), yamledit.ListAction(
+	s, err := yamledit.EditBytes("example.yaml", []byte(yml), yamledit.ListAction(
 		"$",
 		// Add "zoo" with comment
 		yamledit.AddValuesToList(1, yamledit.WithComment("zoo", " comment is added")),

--- a/yamledit/doc_test.go
+++ b/yamledit/doc_test.go
@@ -22,7 +22,7 @@ children:
 		Name string
 	}
 
-	s, err := yamledit.EditBytes([]byte(yml),
+	s, err := yamledit.EditBytes("example.yaml", []byte(yml),
 		yamledit.MapAction(
 			"$",
 			// Edit name to "ryan"

--- a/yamledit/doc_test.go
+++ b/yamledit/doc_test.go
@@ -5,7 +5,6 @@ import (
 	"log"
 	"strings"
 
-	"github.com/goccy/go-yaml/parser"
 	"github.com/suzuki-shunsuke/go-yamledit/yamledit"
 )
 
@@ -23,11 +22,7 @@ children:
 		Name string
 	}
 
-	file, err := parser.ParseBytes([]byte(yml), parser.ParseComments)
-	if err != nil {
-		log.Fatal(err)
-	}
-	actions := []yamledit.Action{
+	s, err := yamledit.EditBytes([]byte(yml),
 		yamledit.MapAction(
 			"$",
 			// Edit name to "ryan"
@@ -59,14 +54,11 @@ children:
 			yamledit.SortList[Child](func(a, b *yamledit.Node[Child]) int {
 				return strings.Compare(a.Value.Name, b.Value.Name)
 			}),
-		),
+		))
+	if err != nil {
+		log.Fatal(err)
 	}
-	for _, act := range actions {
-		if err := act.Run(file.Docs[0].Body); err != nil {
-			log.Fatal(err)
-		}
-	}
-	fmt.Println(file.String())
+	fmt.Println(s)
 	// Output:
 	// name: ryan # comment is kept
 	// gender: male

--- a/yamledit/list_add_test.go
+++ b/yamledit/list_add_test.go
@@ -13,7 +13,7 @@ func ExampleAddValuesToList() {
 - bar
 `
 
-	s, err := yamledit.EditBytes([]byte(yml), yamledit.ListAction("$", yamledit.AddValuesToList(0, "zoo")))
+	s, err := yamledit.EditBytes("example.yaml", []byte(yml), yamledit.ListAction("$", yamledit.AddValuesToList(0, "zoo")))
 	if err != nil {
 		log.Fatal(err)
 	}
@@ -31,7 +31,7 @@ func ExampleAddValuesToList_negative_index() {
 `
 
 	// Add "zoo" to the last position
-	s, err := yamledit.EditBytes([]byte(yml), yamledit.ListAction("$", yamledit.AddValuesToList(-1, "zoo")))
+	s, err := yamledit.EditBytes("example.yaml", []byte(yml), yamledit.ListAction("$", yamledit.AddValuesToList(-1, "zoo")))
 	if err != nil {
 		log.Fatal(err)
 	}
@@ -47,7 +47,7 @@ func ExampleAddValuesToList_with_list_bytes() {
 - foo # comment
 `
 
-	s, err := yamledit.EditBytes([]byte(yml), yamledit.ListAction("$", yamledit.AddValuesToList(-1, yamledit.NewListBytes([]byte(`
+	s, err := yamledit.EditBytes("example.yaml", []byte(yml), yamledit.ListAction("$", yamledit.AddValuesToList(-1, yamledit.NewListBytes([]byte(`
 - bar # comment 1
 - zoo # comment 2
 `)))))

--- a/yamledit/list_add_test.go
+++ b/yamledit/list_add_test.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"log"
 
-	"github.com/goccy/go-yaml/parser"
 	"github.com/suzuki-shunsuke/go-yamledit/yamledit"
 )
 
@@ -14,15 +13,11 @@ func ExampleAddValuesToList() {
 - bar
 `
 
-	file, err := parser.ParseBytes([]byte(yml), parser.ParseComments)
+	s, err := yamledit.EditBytes([]byte(yml), yamledit.ListAction("$", yamledit.AddValuesToList(0, "zoo")))
 	if err != nil {
 		log.Fatal(err)
 	}
-	act := yamledit.ListAction("$", yamledit.AddValuesToList(0, "zoo"))
-	if err := act.Run(file.Docs[0].Body); err != nil {
-		log.Fatal(err)
-	}
-	fmt.Println(file.String())
+	fmt.Println(s)
 	// Output:
 	// - zoo
 	// - foo # comment
@@ -35,16 +30,12 @@ func ExampleAddValuesToList_negative_index() {
 - bar
 `
 
-	file, err := parser.ParseBytes([]byte(yml), parser.ParseComments)
+	// Add "zoo" to the last position
+	s, err := yamledit.EditBytes([]byte(yml), yamledit.ListAction("$", yamledit.AddValuesToList(-1, "zoo")))
 	if err != nil {
 		log.Fatal(err)
 	}
-	// Add "zoo" to the last position
-	act := yamledit.ListAction("$", yamledit.AddValuesToList(-1, "zoo"))
-	if err := act.Run(file.Docs[0].Body); err != nil {
-		log.Fatal(err)
-	}
-	fmt.Println(file.String())
+	fmt.Println(s)
 	// Output:
 	// - foo # comment
 	// - bar
@@ -56,18 +47,14 @@ func ExampleAddValuesToList_with_list_bytes() {
 - foo # comment
 `
 
-	file, err := parser.ParseBytes([]byte(yml), parser.ParseComments)
+	s, err := yamledit.EditBytes([]byte(yml), yamledit.ListAction("$", yamledit.AddValuesToList(-1, yamledit.NewListBytes([]byte(`
+- bar # comment 1
+- zoo # comment 2
+`)))))
 	if err != nil {
 		log.Fatal(err)
 	}
-	act := yamledit.ListAction("$", yamledit.AddValuesToList(-1, yamledit.NewListBytes([]byte(`
-- bar # comment 1
-- zoo # comment 2
-`))))
-	if err := act.Run(file.Docs[0].Body); err != nil {
-		log.Fatal(err)
-	}
-	fmt.Println(file.String())
+	fmt.Println(s)
 	// Output:
 	// - foo # comment
 	// - bar # comment 1

--- a/yamledit/list_edit_test.go
+++ b/yamledit/list_edit_test.go
@@ -13,7 +13,7 @@ func ExampleEditListAction() {
 - bar # comment
 `
 
-	s, err := yamledit.EditBytes([]byte(yml), yamledit.ListAction(
+	s, err := yamledit.EditBytes("example.yaml", []byte(yml), yamledit.ListAction(
 		"$",
 		yamledit.EditListAction[string](
 			func(m *yamledit.List[string]) error {

--- a/yamledit/list_edit_test.go
+++ b/yamledit/list_edit_test.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"log"
 
-	"github.com/goccy/go-yaml/parser"
 	"github.com/suzuki-shunsuke/go-yamledit/yamledit"
 )
 
@@ -14,22 +13,18 @@ func ExampleEditListAction() {
 - bar # comment
 `
 
-	file, err := parser.ParseBytes([]byte(yml), parser.ParseComments)
-	if err != nil {
-		log.Fatal(err)
-	}
-	act := yamledit.ListAction(
+	s, err := yamledit.EditBytes([]byte(yml), yamledit.ListAction(
 		"$",
 		yamledit.EditListAction[string](
 			func(m *yamledit.List[string]) error {
 				return yamledit.RemoveValuesFromSequenceNode(m.Node, 0)
 			},
 		),
-	)
-	if err := act.Run(file.Docs[0].Body); err != nil {
+	))
+	if err != nil {
 		log.Fatal(err)
 	}
-	fmt.Println(file.String())
+	fmt.Println(s)
 	// Output:
 	// - bar # comment
 }

--- a/yamledit/list_remove_test.go
+++ b/yamledit/list_remove_test.go
@@ -14,7 +14,7 @@ children:
   - bar # comment 2
 `
 
-	s, err := yamledit.EditBytes([]byte(yml), yamledit.ListAction(
+	s, err := yamledit.EditBytes("example.yaml", []byte(yml), yamledit.ListAction(
 		"$.children",
 		// Remove foo
 		yamledit.RemoveValuesFromList[string](func(value *yamledit.Node[string]) (bool, error) {

--- a/yamledit/list_remove_test.go
+++ b/yamledit/list_remove_test.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"log"
 
-	"github.com/goccy/go-yaml/parser"
 	"github.com/suzuki-shunsuke/go-yamledit/yamledit"
 )
 
@@ -15,21 +14,17 @@ children:
   - bar # comment 2
 `
 
-	file, err := parser.ParseBytes([]byte(yml), parser.ParseComments)
-	if err != nil {
-		log.Fatal(err)
-	}
-	act := yamledit.ListAction(
+	s, err := yamledit.EditBytes([]byte(yml), yamledit.ListAction(
 		"$.children",
 		// Remove foo
 		yamledit.RemoveValuesFromList[string](func(value *yamledit.Node[string]) (bool, error) {
 			return value.Value == "foo", nil
 		}),
-	)
-	if err := act.Run(file.Docs[0].Body); err != nil {
+	))
+	if err != nil {
 		log.Fatal(err)
 	}
-	fmt.Println(file.String())
+	fmt.Println(s)
 	// Output:
 	// children:
 	//   - bar # comment 2

--- a/yamledit/list_sort_test.go
+++ b/yamledit/list_sort_test.go
@@ -16,21 +16,16 @@ func ExampleSortList() {
 - bar # comment 2
 `
 
-	file, err := parser.ParseBytes([]byte(yml), parser.ParseComments)
-	if err != nil {
-		log.Fatal(err)
-	}
-
-	act := yamledit.ListAction(
+	s, err := yamledit.EditBytes([]byte(yml), yamledit.ListAction(
 		"$",
 		yamledit.SortList[string](func(a, b *yamledit.Node[string]) int {
 			return strings.Compare(a.Value, b.Value)
 		}),
-	)
-	if err := act.Run(file.Docs[0].Body); err != nil {
+	))
+	if err != nil {
 		log.Fatal(err)
 	}
-	fmt.Println(file.String())
+	fmt.Println(s)
 	// Output:
 	// - bar # comment 2
 	// - foo # comment

--- a/yamledit/list_sort_test.go
+++ b/yamledit/list_sort_test.go
@@ -16,7 +16,7 @@ func ExampleSortList() {
 - bar # comment 2
 `
 
-	s, err := yamledit.EditBytes([]byte(yml), yamledit.ListAction(
+	s, err := yamledit.EditBytes("example.yaml", []byte(yml), yamledit.ListAction(
 		"$",
 		yamledit.SortList[string](func(a, b *yamledit.Node[string]) int {
 			return strings.Compare(a.Value, b.Value)

--- a/yamledit/map_edit_test.go
+++ b/yamledit/map_edit_test.go
@@ -17,7 +17,7 @@ age: 10 # keep comment 2
 type: yoo # keep comment 3
 `
 
-	s, err := yamledit.EditBytes([]byte(yml), yamledit.MapAction(
+	s, err := yamledit.EditBytes("example.yaml", []byte(yml), yamledit.MapAction(
 		"$",
 		yamledit.EditMapAction[string, any](
 			// Change the value of the "name" key to "new name"

--- a/yamledit/map_edit_test.go
+++ b/yamledit/map_edit_test.go
@@ -17,11 +17,7 @@ age: 10 # keep comment 2
 type: yoo # keep comment 3
 `
 
-	file, err := parser.ParseBytes([]byte(yml), parser.ParseComments)
-	if err != nil {
-		log.Fatal(err)
-	}
-	act := yamledit.MapAction(
+	s, err := yamledit.EditBytes([]byte(yml), yamledit.MapAction(
 		"$",
 		yamledit.EditMapAction[string, any](
 			// Change the value of the "name" key to "new name"
@@ -68,11 +64,11 @@ type: yoo # keep comment 3
 				return yamledit.SetValueToMappingValue(kv.Node, "yoo-2", false)
 			},
 		),
-	)
-	if err := act.Run(file.Docs[0].Body); err != nil {
+	))
+	if err != nil {
 		log.Fatal(err)
 	}
-	fmt.Println(file.String())
+	fmt.Println(s)
 	// Output:
 	// name: new name # keep comment
 	// age-2: 10 # keep comment 2

--- a/yamledit/map_remove_test.go
+++ b/yamledit/map_remove_test.go
@@ -15,7 +15,7 @@ name: foo
 age: 10 # keep comment
 `
 
-	s, err := yamledit.EditBytes([]byte(yml), yamledit.MapAction(
+	s, err := yamledit.EditBytes("example.yaml", []byte(yml), yamledit.MapAction(
 		"$",
 		yamledit.RemoveKeys(
 			"name",

--- a/yamledit/map_remove_test.go
+++ b/yamledit/map_remove_test.go
@@ -15,22 +15,17 @@ name: foo
 age: 10 # keep comment
 `
 
-	file, err := parser.ParseBytes([]byte(yml), parser.ParseComments)
-	if err != nil {
-		log.Fatal(err)
-	}
-	act := yamledit.MapAction(
+	s, err := yamledit.EditBytes([]byte(yml), yamledit.MapAction(
 		"$",
 		yamledit.RemoveKeys(
 			"name",
 			"id", // unknown key is ignored
 		),
-	)
-
-	if err := act.Run(file.Docs[0].Body); err != nil {
+	))
+	if err != nil {
 		log.Fatal(err)
 	}
-	fmt.Println(file.String())
+	fmt.Println(s)
 	// Output:
 	// age: 10 # keep comment
 }

--- a/yamledit/map_rename_test.go
+++ b/yamledit/map_rename_test.go
@@ -15,7 +15,7 @@ name: foo
 age: 10 # keep comment
 `
 
-	s, err := yamledit.EditBytes([]byte(yml), yamledit.MapAction(
+	s, err := yamledit.EditBytes("example.yaml", []byte(yml), yamledit.MapAction(
 		"$",
 		yamledit.RenameKey( // Rename name to first_name
 			"name",

--- a/yamledit/map_rename_test.go
+++ b/yamledit/map_rename_test.go
@@ -15,11 +15,7 @@ name: foo
 age: 10 # keep comment
 `
 
-	file, err := parser.ParseBytes([]byte(yml), parser.ParseComments)
-	if err != nil {
-		log.Fatal(err)
-	}
-	act := yamledit.MapAction(
+	s, err := yamledit.EditBytes([]byte(yml), yamledit.MapAction(
 		"$",
 		yamledit.RenameKey( // Rename name to first_name
 			"name",
@@ -31,12 +27,11 @@ age: 10 # keep comment
 			"unknown-2",
 			yamledit.Skip,
 		),
-	)
-
-	if err := act.Run(file.Docs[0].Body); err != nil {
+	))
+	if err != nil {
 		log.Fatal(err)
 	}
-	fmt.Println(file.String())
+	fmt.Println(s)
 	// Output:
 	// first_name: foo
 	// age: 10 # keep comment

--- a/yamledit/map_set_test.go
+++ b/yamledit/map_set_test.go
@@ -15,11 +15,7 @@ name: foo # keep comment
 age: 10
 `
 
-	file, err := parser.ParseBytes([]byte(yml), parser.ParseComments)
-	if err != nil {
-		log.Fatal(err)
-	}
-	act := yamledit.MapAction(
+	s, err := yamledit.EditBytes([]byte(yml), yamledit.MapAction(
 		"$",
 		// Edit name to "ryan"
 		yamledit.SetKey("name", "ryan", nil),
@@ -33,12 +29,11 @@ age: 10
 				},
 			},
 		}),
-	)
-
-	if err := act.Run(file.Docs[0].Body); err != nil {
+	))
+	if err != nil {
 		log.Fatal(err)
 	}
-	fmt.Println(file.String())
+	fmt.Println(s)
 	// Output:
 	// name: ryan # keep comment
 	// gender: male

--- a/yamledit/map_set_test.go
+++ b/yamledit/map_set_test.go
@@ -15,7 +15,7 @@ name: foo # keep comment
 age: 10
 `
 
-	s, err := yamledit.EditBytes([]byte(yml), yamledit.MapAction(
+	s, err := yamledit.EditBytes("example.yaml", []byte(yml), yamledit.MapAction(
 		"$",
 		// Edit name to "ryan"
 		yamledit.SetKey("name", "ryan", nil),

--- a/yamledit/map_sort_test.go
+++ b/yamledit/map_sort_test.go
@@ -30,7 +30,7 @@ age: 10
 job: engineer
 `
 
-	s, err := yamledit.EditBytes([]byte(yml), yamledit.MapAction(
+	s, err := yamledit.EditBytes("example.yaml", []byte(yml), yamledit.MapAction(
 		"$",
 		yamledit.SortKey(func(a, b *yamledit.KeyValue[string]) int {
 			if a.Key == b.Key {

--- a/yamledit/map_sort_test.go
+++ b/yamledit/map_sort_test.go
@@ -30,11 +30,7 @@ age: 10
 job: engineer
 `
 
-	file, err := parser.ParseBytes([]byte(yml), parser.ParseComments)
-	if err != nil {
-		log.Fatal(err)
-	}
-	act := yamledit.MapAction(
+	s, err := yamledit.EditBytes([]byte(yml), yamledit.MapAction(
 		"$",
 		yamledit.SortKey(func(a, b *yamledit.KeyValue[string]) int {
 			if a.Key == b.Key {
@@ -45,12 +41,11 @@ job: engineer
 			}
 			return 1
 		}),
-	)
-
-	if err := act.Run(file.Docs[0].Body); err != nil {
+	))
+	if err != nil {
 		log.Fatal(err)
 	}
-	fmt.Println(file.String())
+	fmt.Println(s)
 	// Output:
 	// age: 10
 	// job: engineer

--- a/yamledit/map_test.go
+++ b/yamledit/map_test.go
@@ -14,7 +14,7 @@ work: engineer
 age: 8
 `
 
-	s, err := yamledit.EditBytes([]byte(yml), yamledit.MapAction(
+	s, err := yamledit.EditBytes("example.yaml", []byte(yml), yamledit.MapAction(
 		"$",
 		// Edit name to "ryan"
 		yamledit.SetKey("name", "ryan", nil),

--- a/yamledit/map_test.go
+++ b/yamledit/map_test.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"log"
 
-	"github.com/goccy/go-yaml/parser"
 	"github.com/suzuki-shunsuke/go-yamledit/yamledit"
 )
 
@@ -15,35 +14,27 @@ work: engineer
 age: 8
 `
 
-	file, err := parser.ParseBytes([]byte(yml), parser.ParseComments)
+	s, err := yamledit.EditBytes([]byte(yml), yamledit.MapAction(
+		"$",
+		// Edit name to "ryan"
+		yamledit.SetKey("name", "ryan", nil),
+		// Remove the key "age"
+		yamledit.RemoveKeys("age"),
+		// Rename the key "work" to "job"
+		yamledit.RenameKey("work", "job", yamledit.Skip),
+		// Add the key "gender" after "name"
+		yamledit.SetKey("gender", "male", &yamledit.SetKeyOption{
+			InsertLocations: []*yamledit.InsertLocation{
+				{
+					AfterKey: "name",
+				},
+			},
+		}),
+	))
 	if err != nil {
 		log.Fatal(err)
 	}
-	actions := []yamledit.Action{
-		yamledit.MapAction(
-			"$",
-			// Edit name to "ryan"
-			yamledit.SetKey("name", "ryan", nil),
-			// Remove the key "age"
-			yamledit.RemoveKeys("age"),
-			// Rename the key "work" to "job"
-			yamledit.RenameKey("work", "job", yamledit.Skip),
-			// Add the key "gender" after "name"
-			yamledit.SetKey("gender", "male", &yamledit.SetKeyOption{
-				InsertLocations: []*yamledit.InsertLocation{
-					{
-						AfterKey: "name",
-					},
-				},
-			}),
-		),
-	}
-	for _, act := range actions {
-		if err := act.Run(file.Docs[0].Body); err != nil {
-			log.Fatal(err)
-		}
-	}
-	fmt.Println(file.String())
+	fmt.Println(s)
 	// Output:
 	// name: ryan # comment is kept
 	// gender: male

--- a/yamledit/util.go
+++ b/yamledit/util.go
@@ -11,17 +11,13 @@ import (
 
 // EditFile is a helper function that reads a YAML file, applies actions to its AST, and writes it back.
 func EditFile(path string, actions ...Action) error {
-	b, err := os.ReadFile(path)
-	if err != nil {
-		return fmt.Errorf("read file: %w", err)
-	}
 	f, err := os.Stat(path)
 	if err != nil {
 		return fmt.Errorf("stat file: %w", err)
 	}
-	file, err := parser.ParseBytes(b, parser.ParseComments)
+	file, err := parser.ParseFile(path, parser.ParseComments)
 	if err != nil {
-		return fmt.Errorf("parse YAML: %w", err)
+		return fmt.Errorf("parse file: %w", err)
 	}
 	for _, doc := range file.Docs {
 		for _, act := range actions {
@@ -34,6 +30,22 @@ func EditFile(path string, actions ...Action) error {
 		return fmt.Errorf("edit file: %w", err)
 	}
 	return nil
+}
+
+// EditBytes is a helper function that parses a YAML, applies actions to its AST, and returns the modified YAML string.
+func EditBytes(b []byte, actions ...Action) (string, error) {
+	file, err := parser.ParseBytes(b, parser.ParseComments)
+	if err != nil {
+		return "", fmt.Errorf("parse YAML: %w", err)
+	}
+	for _, doc := range file.Docs {
+		for _, act := range actions {
+			if err := act.Run(doc.Body); err != nil {
+				return "", fmt.Errorf("run action: %w", err)
+			}
+		}
+	}
+	return file.String(), nil
 }
 
 // BytesToNode parses the given YAML bytes and returns the root node.

--- a/yamledit/util.go
+++ b/yamledit/util.go
@@ -26,7 +26,7 @@ func EditFile(filePath string, actions ...Action) error {
 	if err != nil {
 		return fmt.Errorf("stat file: %w", err)
 	}
-	if err := os.WriteFile(filePath, []byte(s), f.Mode()); err != nil {
+	if err := os.WriteFile(filePath, []byte(s), f.Mode()); err != nil { //nolint:gosec
 		return fmt.Errorf("edit file: %w", err)
 	}
 	return nil

--- a/yamledit/util.go
+++ b/yamledit/util.go
@@ -10,34 +10,37 @@ import (
 )
 
 // EditFile is a helper function that reads a YAML file, applies actions to its AST, and writes it back.
-func EditFile(path string, actions ...Action) error {
-	file, err := parser.ParseFile(path, parser.ParseComments)
+func EditFile(filePath string, actions ...Action) error {
+	b, err := os.ReadFile(filePath)
 	if err != nil {
-		return fmt.Errorf("parse file: %w", err)
+		return fmt.Errorf("read file: %w", err)
 	}
-	for _, doc := range file.Docs {
-		for _, act := range actions {
-			if err := act.Run(doc.Body); err != nil {
-				return fmt.Errorf("run action: %w", err)
-			}
-		}
+	s, err := EditBytes(filePath, b, actions...)
+	if err != nil {
+		return fmt.Errorf("edit bytes: %w", err)
 	}
-	f, err := os.Stat(path)
+	if string(b) == s {
+		return nil
+	}
+	f, err := os.Stat(filePath)
 	if err != nil {
 		return fmt.Errorf("stat file: %w", err)
 	}
-	if err := os.WriteFile(path, []byte(file.String()), f.Mode()); err != nil {
+	if err := os.WriteFile(filePath, []byte(s), f.Mode()); err != nil {
 		return fmt.Errorf("edit file: %w", err)
 	}
 	return nil
 }
 
 // EditBytes is a helper function that parses a YAML, applies actions to its AST, and returns the modified YAML string.
-func EditBytes(b []byte, actions ...Action) (string, error) {
+// filePath is used to set the file name in the AST, which is useful for error messages.
+// Even if the file doesn't exist actually, there is no problem.
+func EditBytes(filePath string, b []byte, actions ...Action) (string, error) {
 	file, err := parser.ParseBytes(b, parser.ParseComments)
 	if err != nil {
 		return "", fmt.Errorf("parse YAML: %w", err)
 	}
+	file.Name = filePath
 	for _, doc := range file.Docs {
 		for _, act := range actions {
 			if err := act.Run(doc.Body); err != nil {

--- a/yamledit/util.go
+++ b/yamledit/util.go
@@ -2,11 +2,39 @@ package yamledit
 
 import (
 	"fmt"
+	"os"
 
 	"github.com/goccy/go-yaml"
 	"github.com/goccy/go-yaml/ast"
 	"github.com/goccy/go-yaml/parser"
 )
+
+// EditFile is a helper function that reads a YAML file, applies actions to its AST, and writes it back.
+func EditFile(path string, actions ...Action) error {
+	b, err := os.ReadFile(path)
+	if err != nil {
+		return fmt.Errorf("read file: %w", err)
+	}
+	f, err := os.Stat(path)
+	if err != nil {
+		return fmt.Errorf("stat file: %w", err)
+	}
+	file, err := parser.ParseBytes(b, parser.ParseComments)
+	if err != nil {
+		return fmt.Errorf("parse YAML: %w", err)
+	}
+	for _, doc := range file.Docs {
+		for _, act := range actions {
+			if err := act.Run(doc.Body); err != nil {
+				return fmt.Errorf("run action: %w", err)
+			}
+		}
+	}
+	if err := os.WriteFile(path, []byte(file.String()), f.Mode()); err != nil { //nolint:gosec,mnd
+		return fmt.Errorf("edit file: %w", err)
+	}
+	return nil
+}
 
 // BytesToNode parses the given YAML bytes and returns the root node.
 // Returns an error if the bytes cannot be parsed.

--- a/yamledit/util.go
+++ b/yamledit/util.go
@@ -26,7 +26,7 @@ func EditFile(path string, actions ...Action) error {
 	if err != nil {
 		return fmt.Errorf("stat file: %w", err)
 	}
-	if err := os.WriteFile(path, []byte(file.String()), f.Mode()); err != nil { //nolint:gosec,mnd
+	if err := os.WriteFile(path, []byte(file.String()), f.Mode()); err != nil {
 		return fmt.Errorf("edit file: %w", err)
 	}
 	return nil

--- a/yamledit/util.go
+++ b/yamledit/util.go
@@ -11,10 +11,6 @@ import (
 
 // EditFile is a helper function that reads a YAML file, applies actions to its AST, and writes it back.
 func EditFile(path string, actions ...Action) error {
-	f, err := os.Stat(path)
-	if err != nil {
-		return fmt.Errorf("stat file: %w", err)
-	}
 	file, err := parser.ParseFile(path, parser.ParseComments)
 	if err != nil {
 		return fmt.Errorf("parse file: %w", err)
@@ -25,6 +21,10 @@ func EditFile(path string, actions ...Action) error {
 				return fmt.Errorf("run action: %w", err)
 			}
 		}
+	}
+	f, err := os.Stat(path)
+	if err != nil {
+		return fmt.Errorf("stat file: %w", err)
 	}
 	if err := os.WriteFile(path, []byte(file.String()), f.Mode()); err != nil { //nolint:gosec,mnd
 		return fmt.Errorf("edit file: %w", err)

--- a/yamledit/util.go
+++ b/yamledit/util.go
@@ -10,26 +10,27 @@ import (
 )
 
 // EditFile is a helper function that reads a YAML file, applies actions to its AST, and writes it back.
-func EditFile(filePath string, actions ...Action) error {
+// The function returns true if the file was modified, false otherwise.
+func EditFile(filePath string, actions ...Action) (bool, error) {
 	b, err := os.ReadFile(filePath)
 	if err != nil {
-		return fmt.Errorf("read file: %w", err)
+		return false, fmt.Errorf("read file: %w", err)
 	}
 	s, err := EditBytes(filePath, b, actions...)
 	if err != nil {
-		return fmt.Errorf("edit bytes: %w", err)
+		return false, fmt.Errorf("edit bytes: %w", err)
 	}
 	if string(b) == s {
-		return nil
+		return false, nil
 	}
 	f, err := os.Stat(filePath)
 	if err != nil {
-		return fmt.Errorf("stat file: %w", err)
+		return false, fmt.Errorf("stat file: %w", err)
 	}
 	if err := os.WriteFile(filePath, []byte(s), f.Mode()); err != nil { //nolint:gosec
-		return fmt.Errorf("edit file: %w", err)
+		return false, fmt.Errorf("edit file: %w", err)
 	}
-	return nil
+	return true, nil
 }
 
 // EditBytes is a helper function that parses a YAML, applies actions to its AST, and returns the modified YAML string.

--- a/yamledit/util_test.go
+++ b/yamledit/util_test.go
@@ -4,6 +4,8 @@ import (
 	"errors"
 	"fmt"
 	"log"
+	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/goccy/go-yaml/ast"
@@ -114,6 +116,129 @@ name: updated
 			}
 			if got != tt.want {
 				t.Errorf("got:\n%s\nwant:\n%s", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestEditFile(t *testing.T) { //nolint:cyclop
+	t.Parallel()
+	tests := []struct {
+		name      string
+		yml       string
+		actions   []yamledit.Action
+		want      string
+		wantBool  bool
+		wantErr   bool
+		noFile    bool
+		checkFile bool // if true, verify file content unchanged on error
+	}{
+		{
+			name: "single action modifies file",
+			yml: `name: foo
+age: 10
+`,
+			actions: []yamledit.Action{
+				yamledit.MapAction("$", yamledit.SetKey("name", "bar", nil)),
+			},
+			want: `name: bar
+age: 10
+`,
+			wantBool: true,
+		},
+		{
+			name: "no change",
+			yml: `name: foo
+`,
+			actions: []yamledit.Action{
+				yamledit.MapAction("$", yamledit.SetKey("name", "foo", nil)),
+			},
+			want: `name: foo
+`,
+			wantBool: false,
+		},
+		{
+			name:    "file not found",
+			noFile:  true,
+			wantErr: true,
+		},
+		{
+			name: "action error",
+			yml: `name: foo
+`,
+			actions: []yamledit.Action{
+				errAction{},
+			},
+			wantErr:   true,
+			checkFile: true,
+		},
+		{
+			name: "multiple actions",
+			yml: `name: foo
+age: 10
+`,
+			actions: []yamledit.Action{
+				yamledit.MapAction("$", yamledit.SetKey("name", "bar", nil)),
+				yamledit.MapAction("$", yamledit.RemoveKeys("age")),
+			},
+			want: `name: bar
+`,
+			wantBool: true,
+		},
+		{
+			name: "comments preserved",
+			yml: `name: foo # keep this
+age: 10
+`,
+			actions: []yamledit.Action{
+				yamledit.MapAction("$", yamledit.SetKey("name", "bar", nil)),
+			},
+			want: `name: bar # keep this
+age: 10
+`,
+			wantBool: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			filePath := filepath.Join(t.TempDir(), "test.yaml")
+			if tt.noFile {
+				// Use a path that doesn't exist
+				filePath = filepath.Join(t.TempDir(), "nonexistent.yaml")
+			} else {
+				if err := os.WriteFile(filePath, []byte(tt.yml), 0o600); err != nil {
+					t.Fatal(err)
+				}
+			}
+			got, err := yamledit.EditFile(filePath, tt.actions...)
+			if tt.wantErr {
+				if err == nil {
+					t.Fatal("expected error, got nil")
+				}
+				if tt.checkFile {
+					b, readErr := os.ReadFile(filePath)
+					if readErr != nil {
+						t.Fatal(readErr)
+					}
+					if string(b) != tt.yml {
+						t.Errorf("file was modified on error\ngot:\n%s\nwant:\n%s", string(b), tt.yml)
+					}
+				}
+				return
+			}
+			if err != nil {
+				t.Fatal(err)
+			}
+			if got != tt.wantBool {
+				t.Errorf("got modified=%v, want %v", got, tt.wantBool)
+			}
+			b, err := os.ReadFile(filePath)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if string(b) != tt.want {
+				t.Errorf("got:\n%s\nwant:\n%s", string(b), tt.want)
 			}
 		})
 	}

--- a/yamledit/util_test.go
+++ b/yamledit/util_test.go
@@ -7,7 +7,6 @@ import (
 	"testing"
 
 	"github.com/goccy/go-yaml/ast"
-	"github.com/goccy/go-yaml/parser"
 	"github.com/suzuki-shunsuke/go-yamledit/yamledit"
 )
 
@@ -125,15 +124,11 @@ func ExampleNewBytes() {
 - foo # comment
 `
 
-	file, err := parser.ParseBytes([]byte(yml), parser.ParseComments)
+	s, err := yamledit.EditBytes([]byte(yml), yamledit.ListAction("$", yamledit.AddValuesToList(0, yamledit.NewBytes([]byte("hello # world")))))
 	if err != nil {
 		log.Fatal(err)
 	}
-	act := yamledit.ListAction("$", yamledit.AddValuesToList(0, yamledit.NewBytes([]byte("hello # world"))))
-	if err := act.Run(file.Docs[0].Body); err != nil {
-		log.Fatal(err)
-	}
-	fmt.Println(file.String())
+	fmt.Println(s)
 	// Output:
 	// - hello # world
 	// - foo # comment

--- a/yamledit/util_test.go
+++ b/yamledit/util_test.go
@@ -1,12 +1,124 @@
 package yamledit_test
 
 import (
+	"errors"
 	"fmt"
 	"log"
+	"testing"
 
+	"github.com/goccy/go-yaml/ast"
 	"github.com/goccy/go-yaml/parser"
 	"github.com/suzuki-shunsuke/go-yamledit/yamledit"
 )
+
+type errAction struct{}
+
+func (a errAction) Run(_ ast.Node) error {
+	return errors.New("action error")
+}
+
+func TestEditBytes(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name    string
+		yml     string
+		actions []yamledit.Action
+		want    string
+		wantErr bool
+	}{
+		{
+			name: "no actions",
+			yml: `name: foo
+age: 10
+`,
+			want: `name: foo
+age: 10
+`,
+		},
+		{
+			name: "single action",
+			yml: `name: foo
+age: 10
+`,
+			actions: []yamledit.Action{
+				yamledit.MapAction("$", yamledit.SetKey("name", "bar", nil)),
+			},
+			want: `name: bar
+age: 10
+`,
+		},
+		{
+			name: "multiple actions",
+			yml: `name: foo
+age: 10
+`,
+			actions: []yamledit.Action{
+				yamledit.MapAction("$", yamledit.SetKey("name", "bar", nil)),
+				yamledit.MapAction("$", yamledit.RemoveKeys("age")),
+			},
+			want: `name: bar
+`,
+		},
+		{
+			name: "comments preserved",
+			yml: `name: foo # keep this
+age: 10
+`,
+			actions: []yamledit.Action{
+				yamledit.MapAction("$", yamledit.SetKey("name", "bar", nil)),
+			},
+			want: `name: bar # keep this
+age: 10
+`,
+		},
+		{
+			name:    "invalid YAML",
+			yml:     `{invalid: [`,
+			wantErr: true,
+		},
+		{
+			name: "action error",
+			yml: `name: foo
+`,
+			actions: []yamledit.Action{
+				errAction{},
+			},
+			wantErr: true,
+		},
+		{
+			name: "multi-document YAML",
+			yml: `name: foo
+---
+name: bar
+`,
+			actions: []yamledit.Action{
+				yamledit.MapAction("$", yamledit.SetKey("name", "updated", nil)),
+			},
+			want: `name: updated
+---
+name: updated
+`,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got, err := yamledit.EditBytes([]byte(tt.yml), tt.actions...)
+			if tt.wantErr {
+				if err == nil {
+					t.Fatal("expected error, got nil")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatal(err)
+			}
+			if got != tt.want {
+				t.Errorf("got:\n%s\nwant:\n%s", got, tt.want)
+			}
+		})
+	}
+}
 
 func ExampleNewBytes() {
 	yml := `

--- a/yamledit/util_test.go
+++ b/yamledit/util_test.go
@@ -102,7 +102,7 @@ name: updated
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
-			got, err := yamledit.EditBytes([]byte(tt.yml), tt.actions...)
+			got, err := yamledit.EditBytes("example.yaml", []byte(tt.yml), tt.actions...)
 			if tt.wantErr {
 				if err == nil {
 					t.Fatal("expected error, got nil")
@@ -124,7 +124,7 @@ func ExampleNewBytes() {
 - foo # comment
 `
 
-	s, err := yamledit.EditBytes([]byte(yml), yamledit.ListAction("$", yamledit.AddValuesToList(0, yamledit.NewBytes([]byte("hello # world")))))
+	s, err := yamledit.EditBytes("example.yaml", []byte(yml), yamledit.ListAction("$", yamledit.AddValuesToList(0, yamledit.NewBytes([]byte("hello # world")))))
 	if err != nil {
 		log.Fatal(err)
 	}


### PR DESCRIPTION
## Summary
- Add `EditFile` helper that reads a YAML file, applies actions to its AST, and writes the result back preserving the original file mode
- Add `EditBytes` helper that parses YAML bytes, applies actions, and returns the modified YAML string
- Add table-driven tests for `EditBytes` (7 cases: no actions, single/multiple actions, comment preservation, invalid YAML, action error, multi-document YAML)
- Simplify all 13 Example test functions to use `EditBytes` instead of the verbose `parser.ParseBytes` → `act.Run` → `file.String()` pattern

## Context
Previously, users had to manually call `parser.ParseBytes` / `parser.ParseFile`, iterate over documents, apply actions, and handle writing back. `EditFile` and `EditBytes` encapsulate this boilerplate into simple one-call helpers.

In `EditFile`, `os.Stat` is called just before `WriteFile` (rather than at the top of the function) to minimize the TOCTOU window between checking and using the file mode.

## Test plan
- [x] `go test ./yamledit/...` — all tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)