### PR TITLE
fix: SetKey adjusts child columns when adding new key with map value

### DIFF
--- a/yamledit/map_set.go
+++ b/yamledit/map_set.go
@@ -25,6 +25,7 @@ func SetKey(key, value any, opt *SetKeyOption) MappingNodeAction {
 					return fmt.Errorf("convert key/value to node: %w", err)
 				}
 				copyColumnFromSibling(mvn, m.Node)
+				adjustChildColumns(mvn.Value, mvn.Key.GetToken().Position.Column)
 				idx := findInsertIndex(opt.GetInsertLocations(), m.KeyValues)
 				m.Node.Values = slices.Insert(m.Node.Values, idx, mvn)
 				return nil

--- a/yamledit/map_set_test.go
+++ b/yamledit/map_set_test.go
@@ -202,6 +202,36 @@ age: 10
 `,
 		},
 		{
+			name: "add new key with map value nested",
+			yml: `foo:
+  bar: 1
+`,
+			action: yamledit.MapAction("$.foo", yamledit.SetKey("baz", map[string]any{"qux": false}, nil)),
+			want: `foo:
+  bar: 1
+  baz:
+    qux: false
+`,
+		},
+		{
+			name: "add new key with map value in list",
+			yml: `jobs:
+  test:
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@v6
+`,
+			action: yamledit.MapAction("$.jobs..steps[*]", yamledit.SetKey("with", map[string]any{"persist-credential": false}, nil)),
+			want: `jobs:
+  test:
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          persist-credential: false
+`,
+		},
+		{
 			name: "clear comment on update",
 			yml: `name: foo # important
 age: 10


### PR DESCRIPTION
## Summary

When `SetKey` adds a **new** key with a map value (e.g., `SetKey("with", map[string]any{"persist-credential": false}, nil)`), the child keys in the map value retained their default column positions (col=1). This caused two issues in the serialized output:

1. **Wrong indentation** - child keys were not indented under the parent key
2. **Key name truncation** - e.g., `persist-credential` became `credential` due to the column mismatch

### Root cause

The existing-key update path (`SetValueToMappingValue`) already calls `adjustChildColumns` to fix up nested column positions, but the new-key insertion path in `SetKey` did not. After `copyColumnFromSibling` sets the correct column for the new key itself, its child map values still had default column=1.

### Fix

Added a call to `adjustChildColumns(mvn.Value, mvn.Key.GetToken().Position.Column)` after `copyColumnFromSibling` in the new-key path, matching the behavior of the existing-key update path.

### Before (actual)

```yaml
      - uses: actions/checkout@v6
        # with:
        #   persist-credentials: false
        with:
        credential: false
```

### After (expected)

```yaml
      - uses: actions/checkout@v6
        # with:
        #   persist-credentials: false
        with:
          persist-credential: false
```

## Test plan

- [x] `go run main.go` produces the expected output
- [x] `go test ./yamledit/...` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)