### PR TITLE
ci(security): use takumi guard

### DIFF
--- a/.github/workflows/autofix.yaml
+++ b/.github/workflows/autofix.yaml
@@ -5,9 +5,11 @@ permissions: {}
 jobs:
   autofix:
     runs-on: ubuntu-24.04
-    permissions: {}
+    permissions:
+      id-token: write
     timeout-minutes: 15
     steps:
-      - uses: suzuki-shunsuke/go-autofix-action@ba716cebb7767055bdde0e62bb91d715bde39ab2 # v0.1.12
+      - uses: suzuki-shunsuke/go-autofix-action@9a8682f2dc2a935fe2a2ac96deb03de2dfcb872e # v0.1.13
         with:
           aqua_version: v2.59.1
+          takumi_guard_bot_id: ${{secrets.TAKUMI_GUARD_BOT_ID}}

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -17,6 +17,9 @@ jobs:
       - run: exit 1
   test:
     uses: ./.github/workflows/workflow_call_test.yaml
+    secrets:
+      TAKUMI_GUARD_BOT_ID: ${{secrets.TAKUMI_GUARD_BOT_ID}}
     permissions:
       pull-requests: write
       contents: read
+      id-token: write

--- a/.github/workflows/workflow_call_test.yaml
+++ b/.github/workflows/workflow_call_test.yaml
@@ -1,13 +1,20 @@
 ---
 name: test (workflow_call)
-on: workflow_call
+on:
+  workflow_call:
+    secrets:
+      TAKUMI_GUARD_BOT_ID:
+        required: true
 permissions: {}
 jobs:
   test:
-    uses: suzuki-shunsuke/go-test-full-workflow/.github/workflows/test.yaml@e442a17816baa8a940edc1544cc6e739d870e165 # v5.0.2
+    uses: suzuki-shunsuke/go-test-full-workflow/.github/workflows/test.yaml@98ab396ba72f7b47f7e22aca7346b6e1d7ae4deb # v6.0.0
     with:
       aqua_version: v2.59.1
       golangci-lint-timeout: 120s
+    secrets:
+      TAKUMI_GUARD_BOT_ID: ${{secrets.TAKUMI_GUARD_BOT_ID}}
     permissions:
       pull-requests: write
       contents: read
+      id-token: write


### PR DESCRIPTION
Introduce takumi guard (Go variant) into the GitHub Actions test and autofix workflows.

## Changes

- `.github/workflows/workflow_call_test.yaml`
  - Bump `go-test-full-workflow` ref: `@e442a17816baa8a940edc1544cc6e739d870e165 # v5.0.2` -> `@98ab396ba72f7b47f7e22aca7346b6e1d7ae4deb # v6.0.0`
  - Declare `TAKUMI_GUARD_BOT_ID` secret on `on.workflow_call` (required) and pass it via `secrets:` to the called job
  - Add `id-token: write` to the job permissions

- `.github/workflows/test.yaml`
  - Pass `TAKUMI_GUARD_BOT_ID` secret to the local `workflow_call_test.yaml` call (chain plumbing)
  - Add `id-token: write` to the calling job permissions

- `.github/workflows/autofix.yaml`
  - Bump `suzuki-shunsuke/go-autofix-action` ref: `@ba716cebb7767055bdde0e62bb91d715bde39ab2 # v0.1.12` -> `@9a8682f2dc2a935fe2a2ac96deb03de2dfcb872e # v0.1.13`
  - Add input `takumi_guard_bot_id: ${{secrets.TAKUMI_GUARD_BOT_ID}}`
  - Add `id-token: write` to the `autofix` job permissions (was `permissions: {}`)

## Note

The `go-test-full-workflow` reusable workflow was bumped across a MAJOR version (v5 -> v6).

The `TAKUMI_GUARD_BOT_ID` secret must be configured in the repository (or organization) for these workflows to function.

🤖 Generated with [Claude Code](https://claude.com/claude-code)